### PR TITLE
Fix misprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,7 +589,7 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
         <b class="header">where</b><code>_.where(list, properties)</code>
         <br />
         Вернёт массив из элементов <b>list</b>, для которых совпадают значения для
-        соответсвующих ключей, перечисленные в <b>properties</b>.
+        соответствующих ключей, перечисленные в <b>properties</b>.
       </p>
       <pre>
 _.where(listOfPlays, {author: "Shakespeare", year: 1611});


### PR DESCRIPTION
Fix misprint in `_.where`